### PR TITLE
refactor: Reorder homepage features alphabetically in v2.1.0

### DIFF
--- a/src/1.0/products/index.md
+++ b/src/1.0/products/index.md
@@ -19,5 +19,5 @@ The UnoPim system manages these options and their associated attributes, ensurin
 In addition to product creation, UnoPim offers powerful tools to manage your catalog efficiently:
 
 - **[Product Completeness](./completeness)**: Measure and improve data quality.
-- **[Product Bulk Edit](./bulk-edit)**: Update multiple products at once.
-- **[Dynamic Product Datagrid](./datagrid)**: Customize your grid with dynamic columns and filters.
+- **Product Bulk Edit**: Update multiple products at once.
+- **Dynamic Product Datagrid**: Customize your grid with dynamic columns and filters.

--- a/src/index.md
+++ b/src/index.md
@@ -8,7 +8,7 @@ hero:
   tagline: "Smarter and faster PIM Experience."
   actions:
     - theme: brand
-      text: Get Started
+      text: Get Started →
       link: /2.1/introduction/
     - theme: alt
       text: What’s New
@@ -21,6 +21,36 @@ hero:
     alt: UnoPim
 
 features:
+  - title: AI Agent & Magic AI
+    details: Use the AI Agent Chat with 32+ PIM tools and Magic AI to automate product data enrichment across 10+ providers.
+    icon: 🤖
+    link: /2.1/ai-agent/
+
+  - title: Attributes & Family
+    details: Define and assign attributes and families with swatch types and video support to standardize product information.
+    icon: 🧩
+    link: /2.1/attribute/
+
+  - title: Dashboard
+    details: Get a comprehensive overview with product statistics, activity charts, completeness scores, and channel readiness.
+    icon: 📊
+    link: /2.1/dashboard/
+
+  - title: Import & Export
+    details: Import and export catalog data with drag-and-drop upload, real-time tracking, and pause/resume controls.
+    icon: 🔁
+    link: /2.1/data-transfer/
+
+  - title: Locales and Currencies
+    details: Set up locales and currencies to support multilingual and multi-currency product catalogs with AI-powered translation.
+    icon: 🌍
+    link: /2.1/settings/locale/
+
+  - title: Notifications & Webhooks
+    details: Stay informed with in-app notifications and automate workflows with product update webhooks.
+    icon: 🔔
+    link: /2.1/notifications/
+
   - title: Products and Categories
     details: Create and manage product records and category hierarchies with completeness scoring and bulk edit capabilities.
     icon: 📦
@@ -30,34 +60,4 @@ features:
     details: Configure users, roles, and permissions to control access and responsibilities within UnoPim.
     icon: 👥
     link: /2.1/settings/roles/
-
-  - title: Locales and Currencies
-    details: Set up locales and currencies to support multilingual and multi-currency product catalogs with AI-powered translation.
-    icon: 🌍
-    link: /2.1/settings/locale/
-
-  - title: Attributes & Family
-    details: Define and assign attributes and families with swatch types and video support to standardize product information.
-    icon: 🧩
-    link: /2.1/attribute/
-
-  - title: Import & Export
-    details: Import and export catalog data with drag-and-drop upload, real-time tracking, and pause/resume controls.
-    icon: 🔁
-    link: /2.1/data-transfer/
-
-  - title: AI Agent & Magic AI
-    details: Use the AI Agent Chat with 32+ PIM tools and Magic AI to automate product data enrichment across 10+ providers.
-    icon: 🤖
-    link: /2.1/ai-agent/
-
-  - title: Dashboard
-    details: Get a comprehensive overview with product statistics, activity charts, completeness scores, and channel readiness.
-    icon: 📊
-    link: /2.1/dashboard/
-
-  - title: Notifications & Webhooks
-    details: Stay informed with in-app notifications and automate workflows with product update webhooks.
-    icon: 🔔
-    link: /2.1/notifications/
 ---


### PR DESCRIPTION
Reordered the 8 feature cards on the homepage ([src/index.md](vscode-webview://1kv0ocqsr1qecvfrgobu60hca8jjfs4d7vcgs7tmrsaffi7thiu6/src/index.md)) alphabetically A→Z by title for easier scanning: AI Agent → Attributes → Dashboard → Import & Export → Locales → Notifications → Products → Users.